### PR TITLE
Feat:Complete the sfml class

### DIFF
--- a/src/Graphical/SFML/SFML.cpp
+++ b/src/Graphical/SFML/SFML.cpp
@@ -112,8 +112,10 @@ sf::Sprite SFMLlib::getSprite(std::shared_ptr<IEntity> entity)
         _textures[path] = texture;
     }
     sprite.setPosition(entity->getPos()[0], entity->getPos()[1]);
-    sprite.setScale(entity->getSize()[0], entity->getSize()[1]);
+    sprite.setScale(entity->getSize()[0] / _textures[path].getSize().x,
+                    entity->getSize()[1] / _textures[path].getSize().y);
     sprite.setRotation(entity->getRotation());
+    sprite.setTexture(_textures[path]);
     return sprite;
 }
 

--- a/src/Graphical/SFML/SFML.cpp
+++ b/src/Graphical/SFML/SFML.cpp
@@ -9,7 +9,7 @@
 
 SFMLlib::SFMLlib()
 {
-    _window.create(sf::VideoMode(1920, 1080), "Arcade", sf::Style::Close);
+    _window.create(sf::VideoMode(1920, 1080), "Arcade", sf::Style::Close | sf::Style::Fullscreen);
     _window.setFramerateLimit(60);
     if (!isWindowOpen())
         throw Error("SFML: Failed to create window");


### PR DESCRIPTION
I added the fullscreen VideoMode option to avoid the fact that the screen spawns in the middle of the screen and needs to me moved to close it.
For now, the only way to close is `ALT+F4`, but since the keybinds are set, it will be possible to properly close the window.

I also fixed the size of the entities to display. before the `setSize` function took the growing ratio, now it takes the needed size.