### PR TITLE
feat: catch throw display in Core

### DIFF
--- a/src/Core/Core.cpp
+++ b/src/Core/Core.cpp
@@ -158,9 +158,24 @@ void Arcade::Core::updateDraw()
     code = _gameLib->simulate();
     if (code != 0)
         changeGameFromMenu(code);
-    _graphicLib->playSound(_gameLib->getSounds());
-    _graphicLib->displayEntities(_gameLib->getEntities());
-    _graphicLib->displayText(_gameLib->getTexts());
+
+    try {
+        _graphicLib->playSound(_gameLib->getSounds());
+    } catch (const std::exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    try {
+        _graphicLib->displayEntities(_gameLib->getEntities());
+    } catch (const std::exception& e) {
+        std::cout << e.what() << std::endl;
+    }
+
+    try {
+        _graphicLib->displayText(_gameLib->getTexts());
+    } catch (const std::exception& e) {
+        std::cout << e.what() << std::endl;
+    }
 }
 
 void Arcade::Core::renderDraw()

--- a/src/Graphical/SFML/SFML.cpp
+++ b/src/Graphical/SFML/SFML.cpp
@@ -107,7 +107,7 @@ sf::Sprite Arcade::SFMLlib::getSprite(std::shared_ptr<IEntity> entity)
     if (_textures.find(path) == _textures.end()) {
         sf::Texture texture;
         if (!texture.loadFromFile(path + ".png")) {
-            throw Error("SFML: Failed to load texture");
+            return sprite;
         }
         _textures[path] = texture;
     }


### PR DESCRIPTION
Catch the following throw Error in Core:
- display text
- display entity
- play sound

Remove the throw in display Entity in SFML.